### PR TITLE
Create publish to PyPI workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,28 +3,28 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tag
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
-      
+
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      
+
       - name: Install pypa/build
         run: python -m pip install build --user
 
       - name: Build wheel and source dist
         run: python -m build --sdist --wheel --outdir dist/ .
-    
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Adds GitHub action to publish wheel and sdist to PyPI on a published release

Closes #64 