### PR TITLE
linguist - ignore documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+notebooks/** linguist-documentation
+datasets/** linguist-documentation
+docs/** linguist-documentation


### PR DESCRIPTION
Ignore docs, notebooks and dataset folders from GitHubs language detection tool