### PR TITLE
Update and stabilise docs requirements

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,7 @@ FairLens is a tool to help people assess the fairness of datasets and models in 
    :hidden:
    :titlesonly:
 
+   user_guide/fairness.rst
    user_guide/index
    reference/index
    contributing

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,15 +55,15 @@ test =
     pytest-cov>=2
 
 doc =
-    sphinx~=4.1
-    ipython~=7.26
-    m2r2==0.3.1
-    pydata-sphinx-theme==0.6.3
-    sphinx-panels==0.6.0
-    sphinxcontrib-bibtex==2.3.0
-    pandoc==1.1.0
-    nbsphinx==0.8.7
-    nbsphinx-link==1.3.0
+    sphinx~=4.3.1
+    ipython~=7.30.1
+    m2r2~=0.3.1
+    pydata-sphinx-theme~=0.7.2
+    sphinx-panels~=0.6.0
+    sphinxcontrib-bibtex~=2.3.0
+    pandoc~=2.0.1
+    nbsphinx~=0.8.7
+    nbsphinx-link~=1.3.0
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Updated the documentation extras (ie.`fairlens[doc]`) and pinned the major+minor versions for each requirement.

This fixes currently failing build-docs job in the CI and makes it less likely to happen again.

The issue was that the `pydata-sphinx-theme` was pinned to a version (`0.6.3`) that became incompatible with `sphinx==4.3` (we had only pinned to the major version i.e. `sphinx ~= 4.1`.