### PR TITLE
Bug Fix: Invalid group detected for dtype = "boolean" when plotting

### DIFF
--- a/src/fairlens/utils.py
+++ b/src/fairlens/utils.py
@@ -4,6 +4,7 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_bool_dtype
 
 
 class DistrType(Enum):
@@ -314,7 +315,7 @@ def get_predicates_mult(
         if isinstance(group, dict):
             remaining_groups.append((i, group))
         else:
-            if not isinstance(group, pd.Series) or group.dtype != "bool":
+            if not isinstance(group, pd.Series) or not is_bool_dtype(group):
                 raise ValueError(
                     "Invalid group detected. Groups must be either dictionaries or pandas series' of bools."
                 )


### PR DESCRIPTION
When using the `attr_distr_plot` function the following error was encountered: 

```
File ~/venv/lib/python3.8/site-packages/fairlens/plot/distr.py:77, in distr_plot(df, target_attr, groups, distr_type, show_hist, show_curve, shade, normalize, cmap, ax)
     74 if ax is None:
     75     ax = plt.gca()
---> 77 preds = utils.get_predicates_mult(df, groups)
     79 cmap = cmap or sns.color_palette("deep")
     80 palette = itertools.cycle(cmap)

File ~/venv/lib/python3.8/site-packages/fairlens/utils.py:318, in get_predicates_mult(df, groups)
    316     else:
    317         if not isinstance(group, pd.Series) or group.dtype != "bool":
--> 318             raise ValueError(
    319                 "Invalid group detected. Groups must be either dictionaries or pandas series' of bools."
    320             )
    322         predicates[i] = group
    324 # Check all attributes are valid

ValueError: Invalid group detected. Groups must be either dictionaries or pandas series' of bools.
```

This was because the `groups` were created with type "boolean" which incorrectly fails the comparison `group.dtype != "bool"`.  Using the pandas `is_bool_dtype` avoids this